### PR TITLE
Fix/timeline navigation with partial pagination

### DIFF
--- a/components/layout/months.tsx
+++ b/components/layout/months.tsx
@@ -5,6 +5,7 @@ import { IAggregatedChangelogs, IImagePreviewMeta } from "lib/models/view";
 import useTimelineStore from "lib/state/use-timeline-store";
 import { useRouter } from "next/router";
 import Timeline from "./timeline";
+import React from "react";
 
 interface IMonthsProps {
   monthChangelogsMap: IAggregatedChangelogs;
@@ -24,10 +25,34 @@ const Months = ({ monthChangelogsMap }: IMonthsProps) => {
       return monthChangelogsMap[date];
     });
 
+  // check for query params: year = YYYY on load, if so scroll to that year
+  React.useLayoutEffect(() => {
+    // if year && the first item in sortedChangelogsArrayByMonth is not the year, scroll to that year
+
+    const year = router.asPath.split("year=")[1];
+
+    if (
+      year &&
+      sortedChangelogsArrayByMonth[0] &&
+      dayjs(sortedChangelogsArrayByMonth[0][0].publishedAt).format("YYYY") !== year
+    ) {
+      const yearIndex = sortedChangelogsArrayByMonth.findIndex((changelogs) => {
+        return dayjs(changelogs[0].publishedAt).format("YYYY") === year;
+      });
+      if (yearIndex !== -1) {
+        window.scrollTo({
+          top: document.getElementById(`timeline-month-${yearIndex}`)?.offsetTop - 70,
+          behavior: "smooth",
+        });
+      }
+    }
+  }, [router.asPath, monthChangelogsMap]);
+
   return (
     <>
       {sortedChangelogsArrayByMonth.map((changelogs, index) => (
         <Timeline
+          id={`timeline-month-${index}`}
           key={index}
           date={dayjs(Object.keys(monthChangelogsMap)[index]).format("MMM YYYY")}
         >
@@ -36,9 +61,9 @@ const Months = ({ monthChangelogsMap }: IMonthsProps) => {
             paddingBottom={index === sortedChangelogsArrayByMonth.length - 1 ? 0 : [12, 16, 20]}
           >
             <VStack
-              onClick={() => {
-                timeline.setView("weeks");
-              }}
+              // onClick={() => {
+              //   timeline.setView("weeks");
+              // }}
               cursor="pointer"
             >
               <Box
@@ -49,7 +74,11 @@ const Months = ({ monthChangelogsMap }: IMonthsProps) => {
                 display="flex"
                 onClick={() => {
                   timeline.setView("weeks");
-                  router.push(`/page/${changelogs[0].weeklyViewPage}#weeks`);
+                  router.push(
+                    `/page/${changelogs[0].weeklyViewPage}#weeks?month=${dayjs(
+                      Object.keys(monthChangelogsMap)[index]
+                    ).format("MM")}`
+                  );
                 }}
                 position="relative"
               >

--- a/components/layout/months.tsx
+++ b/components/layout/months.tsx
@@ -34,8 +34,6 @@ const Months = ({ monthChangelogsMap }: IMonthsProps) => {
           <Box
             display="flex"
             paddingBottom={index === sortedChangelogsArrayByMonth.length - 1 ? 0 : [12, 16, 20]}
-            position="relative"
-            top="-8px"
           >
             <VStack
               onClick={() => {

--- a/components/layout/timeline.tsx
+++ b/components/layout/timeline.tsx
@@ -1,11 +1,13 @@
 import { Box, HStack, Text, VStack, useMediaQuery } from "@chakra-ui/react";
-import BackButton from "components/core/timeline/back-button"
+import BackButton from "components/core/timeline/back-button";
 import { useRouter } from "next/router";
 import { ReactNode, useEffect, useState } from "react";
 
 export interface TimelineProps {
   date: string;
   children: ReactNode;
+  id?: string;
+  className?: string;
 }
 
 const Timeline = (props: TimelineProps) => {
@@ -21,6 +23,8 @@ const Timeline = (props: TimelineProps) => {
 
   return (
     <HStack
+      id={props.id}
+      className={props.className}
       display="flex"
       position="relative"
       justifyContent="center"
@@ -31,9 +35,7 @@ const Timeline = (props: TimelineProps) => {
     >
       {isLargerThan768 && (
         <VStack position="relative" top={isOpen ? "" : "-8px"} width="120px" spacing={4}>
-          {isOpen && (
-            <BackButton/>
-          )}
+          {isOpen && <BackButton />}
           <Text fontSize="16px" color="#868E96" alignItems="start" width="125px">
             {date}
           </Text>
@@ -73,9 +75,7 @@ const Timeline = (props: TimelineProps) => {
         <VStack alignItems="start" spacing={[0, 0, 2]}>
           {!isLargerThan768 && (
             <VStack position="relative" top="-8px" spacing={4} mb={[4, 4]}>
-              {isOpen && (
-                <BackButton/>
-              )}
+              {isOpen && <BackButton />}
               <Text fontSize="16px" color="#868E96" alignItems="start" width="full">
                 {date}
               </Text>

--- a/components/layout/weeks.tsx
+++ b/components/layout/weeks.tsx
@@ -14,7 +14,7 @@ const Weeks = ({ slugs }: IWeeksProps) => {
     <>
       {Articles.map((Article, index) => (
         // @ts-ignore
-        <Article key={index} hideLayout={true} hideHead={true} hideAuthors={true} />
+        <Article key={index} index={index} hideLayout={true} hideHead={true} hideAuthors={true} />
       ))}
     </>
   );

--- a/components/layout/years.tsx
+++ b/components/layout/years.tsx
@@ -36,8 +36,6 @@ const Years = ({ yearChangelogsMap }: IYearsProps) => {
           <Box
             display="flex"
             paddingBottom={index === sortedChangelogsByYear.length - 1 ? 0 : [12, 16, 20]}
-            position="relative"
-            top="-8px"
           >
             <VStack
               onClick={() => {

--- a/components/layout/years.tsx
+++ b/components/layout/years.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, GridItem, HStack, Image, useMediaQuery, VStack, } from "@chakra-ui/react";
+import { Box, Grid, GridItem, HStack, Image, useMediaQuery, VStack } from "@chakra-ui/react";
 import MoreItems from "components/core/more-items";
 import LargeGrid from "components/core/years/large-grid";
 import MediumGrid from "components/core/years/medium-grid";
@@ -17,7 +17,7 @@ const Years = ({ yearChangelogsMap }: IYearsProps) => {
   const timeline = useTimelineStore();
   const router = useRouter();
   const [isLargerThan768] = useMediaQuery("(min-width: 768px)");
-  
+
   const sortedYearKeys = Object.keys(yearChangelogsMap || {}).sort((a, b) => {
     const dateA = new Date(a);
     const dateB = new Date(b);
@@ -27,7 +27,6 @@ const Years = ({ yearChangelogsMap }: IYearsProps) => {
   const sortedChangelogsByYear: IImagePreviewMeta[][] = sortedYearKeys.map((year) => {
     return yearChangelogsMap[year];
   });
-
 
   return (
     <>
@@ -40,7 +39,11 @@ const Years = ({ yearChangelogsMap }: IYearsProps) => {
             <VStack
               onClick={() => {
                 timeline.setView("months");
-                router.push(`/page/${index}#months`);
+                router.push(
+                  `/page/${changelogs[0]?.monthlyViewPage || 0}#months?year=${dayjs(
+                    sortedYearKeys[index]
+                  ).format("YYYY")}`
+                );
               }}
               cursor="pointer"
             >

--- a/components/mdx-layout.tsx
+++ b/components/mdx-layout.tsx
@@ -108,8 +108,6 @@ export const MdxLayout = (props: MdxLayoutProps) => {
           // w="100%"
           maxW="682px"
           // px={defaultPx(32)}
-          position={props.hideLayout ? "relative" : "static"}
-          top={props.hideLayout ? "-8px" : 0}
         >
           {/* Article header */}
           <VStack align="start" spacing={[4, 4, 6]}>

--- a/components/paginated-articles.tsx
+++ b/components/paginated-articles.tsx
@@ -119,7 +119,7 @@ export const PaginatedArticles = ({
               >
                 <VStack align={["stretch", "stretch", "center"]}>
                   {page === 0 && hasMorePage ? (
-                    <Link href="/page/1">
+                    <Link href={`/page/1#${timeline.view}`}>
                       <Button variant="landingOutline" size="landingLg">
                         Load more
                       </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import Months from "components/layout/months";
 import Years from "components/layout/years";
 import Weeks from "components/layout/weeks";
 import useTimelineStore from "lib/state/use-timeline-store";
-import { IAggregatedChangelogs } from "lib/models/view";
+import { IAggregatedChangelogs, IImagePreviewMeta } from "lib/models/view";
 import { AnimatePresence, motion } from "framer-motion";
 import { TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import React from "react";
@@ -104,7 +104,7 @@ export async function getStaticProps({ params }) {
       slug: item.slug,
       publishedAt: item.publishedAt,
       weeklyViewPage: Math.floor((index + 1) / ITEMS_PER_PAGE),
-    });
+    } as IImagePreviewMeta);
     return acc;
   }, {});
 
@@ -121,15 +121,20 @@ export async function getStaticProps({ params }) {
     if (!acc[year]) {
       acc[year] = [];
     }
+
     acc[year].push({
       imageUrl: item.headerImage,
       slug: item.slug,
       publishedAt: item.publishedAt,
       weeklyViewPage: Math.floor((index + 1) / ITEMS_PER_PAGE),
-      montlyViewPage: Math.floor(
-        Object.keys(monthChangelogsMap).indexOf(`${year}-${date.getMonth() + 1}`) / ITEMS_PER_PAGE
+      monthlyViewPage: Math.floor(
+        (Object.keys(monthChangelogsMap)
+          .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())
+          .indexOf(`${year}-${date.getMonth() + 1}`) +
+          1) /
+          ITEMS_PER_PAGE
       ),
-    });
+    } as IImagePreviewMeta);
     return acc;
   }, {});
 

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <title>June Changelog</title>
         <link>https://changelog.june.so</link>
         <description>How June gets better every week</description>
-        <lastBuildDate>Fri, 23 Jun 2023 09:29:38 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 27 Jun 2023 04:42:02 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Feed for June changelog</generator>
         <image>


### PR DESCRIPTION
Scrolling to the correct item that belong to a specific year or month when navigating between Years -> Months -> Weeks view.

Fixes https://github.com/juneHQ/changelog/issues/22 .