### PR TITLE
Remove load more button when the page is the last page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ build
 out/*
 
 changelog-images/
+TODO

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -1,17 +1,17 @@
-import React, { ReactNode } from "react";
-import Link from "next/link";
-import Head from "next/head";
-import { defaultPx } from "lib/utils/default-container-px";
-import TryBanner from "components/core/try-banner";
-import Navbar from "components/core/navbar";
-import { Footer } from "components/core/footer";
-import { Box, Button, Container, Heading, HStack, Text, VStack } from "@chakra-ui/react";
-import TimeSelectionTabs from "../core/time-selection-tabs";
-import useTimelineStore from "lib/state/use-timeline-store";
-import { motion } from "framer-motion";
-import useAnimatePageStore from "lib/state/use-animate-page-store";
-import { useRouter } from "next/router";
-import usePageStatusStore from "lib/state/use-page-status-store";
+import React, { ReactNode } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import Head from 'next/head';
+import { defaultPx } from 'lib/utils/default-container-px';
+import useTimelineStore from 'lib/state/use-timeline-store';
+import usePageStatusStore from 'lib/state/use-page-status-store';
+import useAnimatePageStore from 'lib/state/use-animate-page-store';
+import { motion } from 'framer-motion';
+import TryBanner from 'components/core/try-banner';
+import Navbar from 'components/core/navbar';
+import { Footer } from 'components/core/footer';
+import { Box, Button, Container, Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import TimeSelectionTabs from '../core/time-selection-tabs';
 
 export interface MainLayoutProps {
   page?: number;
@@ -79,7 +79,7 @@ export const MainLayout = ({
   const hasMorePage =
     !infiniteScrollingView &&
     page !== undefined &&
-    page < Math.floor(totalItems[timeline.view] / itemsPerPage);
+    page < (Math.floor(totalItems[timeline.view] / itemsPerPage) - 1);
 
   const isInBlogPage = router.pathname.startsWith("/changelogs/");
 

--- a/components/layout/months.tsx
+++ b/components/layout/months.tsx
@@ -1,12 +1,12 @@
-import { Box, Grid, HStack, Image, Skeleton, VStack } from "@chakra-ui/react";
-import MoreItems from "components/core/more-items";
-import dayjs from "dayjs";
-import { IAggregatedChangelogs, IImagePreviewMeta } from "lib/models/view";
-import { useRouter } from "next/router";
-import Timeline from "./timeline";
-import React from "react";
-import { motion } from "framer-motion";
-import LazyLoad from "react-lazyload";
+import LazyLoad from 'react-lazyload';
+import React from 'react';
+import { useRouter } from 'next/router';
+import { IAggregatedChangelogs, IImagePreviewMeta } from 'lib/models/view';
+import { motion } from 'framer-motion';
+import dayjs from 'dayjs';
+import MoreItems from 'components/core/more-items';
+import { Box, Grid, HStack, Image, VStack } from '@chakra-ui/react';
+import Timeline from './timeline';
 
 interface IMonthsProps {
   monthChangelogsMap: IAggregatedChangelogs;
@@ -79,9 +79,6 @@ const Months = ({ monthChangelogsMap, isInfiniteScrollingView }: IMonthsProps) =
               paddingBottom={index === sortedChangelogsArrayByMonth.length - 1 ? 0 : [12, 16, 20]}
             >
               <VStack
-                // onClick={() => {
-                //   timeline.setView("weeks");
-                // }}
                 borderRadius={"16px"}
                 overflow="hidden"
                 cursor="pointer"
@@ -147,9 +144,6 @@ const Months = ({ monthChangelogsMap, isInfiniteScrollingView }: IMonthsProps) =
                     ) : (
                       <HStack height="100%">
                         <motion.div
-                          // layoutId={`${changelogs[0]?.slug}`}
-                          // initial="visible"
-                          // transition={{ duration: 0.6 }}
                           layoutId={
                             index === 0 && isInfiniteScrollingView ? changelogs[0]?.slug : ``
                           }

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <title>June Changelog</title>
         <link>https://changelog.june.so</link>
         <description>How June gets better every week</description>
-        <lastBuildDate>Mon, 05 Aug 2024 08:53:12 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 06 Aug 2024 09:05:49 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Feed for June changelog</generator>
         <image>


### PR DESCRIPTION
When the page is the last page there should be no load more button:

<img width="1031" alt="Screenshot 2024-08-06 at 11 07 18" src="https://github.com/user-attachments/assets/407f19fc-dd24-40c5-84a5-983fe3f2780b">
