### PR TITLE
Fix the logged in status for the changelog

### DIFF
--- a/lib/state/use-auth.ts
+++ b/lib/state/use-auth.ts
@@ -14,7 +14,7 @@ export const useAuth = () => {
           mode: 'cors',
         });
         const data = await response.json();
-        setLoggedIn(data.loggedIn);
+        setLoggedIn(data.logged_in);
       } catch (error) {
         setLoggedIn(false);
       }

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <title>June Changelog</title>
         <link>https://changelog.june.so</link>
         <description>How June gets better every week</description>
-        <lastBuildDate>Tue, 06 Aug 2024 11:21:22 GMT</lastBuildDate>
+        <lastBuildDate>Tue, 06 Aug 2024 12:19:10 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Feed for June changelog</generator>
         <image>


### PR DESCRIPTION
Fix the hook that returns the logged in status

<img width="461" alt="Screenshot 2024-08-06 at 14 19 14" src="https://github.com/user-attachments/assets/de5f8ebc-c931-44a8-9e5a-d2f66c11c7f7">
